### PR TITLE
docs: README corrections

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -22,7 +22,7 @@ Only run this full orchestration if you're specifically experimenting with the c
 
 All images are stored in public [registry](https://hub.docker.com/u/synonymsoft) and by default the `latest` tag is used.
 
-The image tag and registry are envinroment variables, so if needed they could be changed
+The image tag and registry are environment variables, so if needed they could be changed
 
 ```
 REGISTRY - registry by default synonymsoft

--- a/Readme.md
+++ b/Readme.md
@@ -43,7 +43,7 @@ docker compose up -d
 
 ### ⚙️ Setup
 
-This repo uses `pubky/pkarr`, `pubky/pubky`, `pubky/pubky-nexus` and `pubky/pubky-app` as directly as the moment.
+This repo uses `pubky/pkarr`, `pubky/pubky-core`, `pubky/pubky-nexus` and `pubky/pubky-app` as directly as the moment.
 
 Make a copy of `.env-sample` into `.env` and set your preferences for `mainnet` or `testnet`.
 
@@ -61,7 +61,7 @@ Your directory should look like this:
 your_working_directory/
 ├── pubky-docker/ # this project!
 ├── pkarr/
-├── pubky/
+├── pubky-core/
 ├── pubky-nexus/
 ├── pubky-app/
 ```

--- a/Readme.md
+++ b/Readme.md
@@ -43,7 +43,7 @@ docker compose up -d
 
 ### ⚙️ Setup
 
-This repo uses `pubky/pkarr`, `pubky/pubky-core`, `pubky/pubky-nexus` and `pubky/pubky-app` as directly as the moment.
+This setup builds directly from the `pubky/pkarr`, `pubky/pubky-core`, `pubky/pubky-nexus`, and `pubky/pubky-app` repositories.
 
 Make a copy of `.env-sample` into `.env` and set your preferences for `mainnet` or `testnet`.
 


### PR DESCRIPTION
## Summary
- Correct `pubky/pubky` → `pubky/pubky-core` (repo list + directory tree)
- Fix typo `envinroment` → `environment`
- Rewrite awkward source-build sentence