### PR TITLE
Add homeserver compose profile

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -2,7 +2,7 @@
 # DOCKER COMPOSE
 #####
 
-# Full stack on `docker compose up`; use `docker compose --profile backend up` for backend only
+# Full stack on `docker compose up`; use `--profile backend` or `--profile homeserver` for smaller stacks
 COMPOSE_PROFILES=backend,pubky-app
 
 # mainnet or testnet network

--- a/Readme.md
+++ b/Readme.md
@@ -42,16 +42,24 @@ Copy `.env-sample` to `.env` for default `testnet` config:
 cp .env-sample .env
 ```
 
+The sample `.env` sets `COMPOSE_PROFILES=backend,pubky-app`, so `docker compose up` starts the full stack by default.
+
 Start the full stack:
 
 ```bash
-docker compose up -d
+docker compose up -d --pull always --no-build
 ```
 
-Backend only:
+Homeserver only:
 
 ```bash
-docker compose --profile backend up -d
+docker compose --profile homeserver up -d --pull always --no-build
+```
+
+Backend only (backend for pubky.app instance):
+
+```bash
+docker compose --profile backend up -d --pull always --no-build
 ```
 
 This path does not clone or build service repositories. You only need the compose files from this project and a configured `.env`.
@@ -63,13 +71,19 @@ This path does not clone or build service repositories. You only need the compos
 If you have already cloned the service repositories and checked out refs yourself, you can use Compose directly:
 
 ```bash
-docker compose --profile backend --profile pubky-app up -d
+docker compose up -d --build
 ```
 
-Backend only (If you want to run your own frontend separately):
+Homeserver only:
 
 ```bash
-docker compose --profile backend up -d
+docker compose --profile homeserver up -d --build
+```
+
+Backend only (If you want to run your own pubky.app frontend separately):
+
+```bash
+docker compose --profile backend up -d --build
 ```
 
 ### CLI
@@ -125,4 +139,3 @@ Run the script again to pick new refs:
 For existing repositories, the script refuses to change refs if there are local changes. Commit, stash, or clean those changes first, then rerun.
 
 The script records the last built commit per Compose service in `.build-state`. On later runs, unchanged services skip the image build step. If `.build-state` is complete for your selected profile set, you can start the stack without going through ref selection again.
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   # 1. PostgreSQL (shared by Homeserver and Homegate)
   postgres:
-    profiles: [backend]
+    profiles: [backend, homeserver]
     container_name: postgres
     image: postgres:17-alpine
     restart: always
@@ -22,7 +22,7 @@ services:
 
   # 2. Pubky Homeserver
   homeserver:
-    profiles: [backend]
+    profiles: [backend, homeserver]
     container_name: homeserver
     image: "${REGISTRY:-synonymsoft}/homeserver-${HOMESERVER_ENV:-testnet}:${HOMESERVER_TAG:-latest}"
     restart: always


### PR DESCRIPTION
For the development of 'simple' Pubky apps, it is enough to just run the HS and its DB.
I also changed to compose up commands to be more precise with whether the images should be built or pulled.

## Summary
- Add a homeserver Compose profile for postgres + homeserver only.
- Document public-image and source-build startup commands.