### PR TITLE
chore: use pubky-homeserver repository

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -6,7 +6,7 @@
 
 One-click setup to run a local Pubky Social stack. This orchestration can run:
 
-- [Pubky Homeserver](https://github.com/pubky/pubky-core/tree/main/pubky-homeserver), from `pubky/pubky-core`
+- [Pubky Homeserver](https://github.com/pubky/pubky-homeserver/tree/main/pubky-homeserver), from `pubky/pubky-homeserver`
 - [Pubky Nexus](https://github.com/pubky/pubky-nexus), from `pubky/pubky-nexus`
 - [Homegate](https://github.com/pubky/homegate), from `pubky/homegate`
 - [Pubky App](https://github.com/pubky/pubky-app), as the `pubky-app` Compose service
@@ -120,7 +120,7 @@ After running the script, your workspace will look similar to this:
 ```text
 your_working_directory/
 ├── pubky-docker/
-├── pubky-core/
+├── pubky-homeserver/
 ├── pubky-nexus/
 ├── homegate/
 └── pubky-app/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
     image: "${REGISTRY:-synonymsoft}/homeserver-${HOMESERVER_ENV:-testnet}:${HOMESERVER_TAG:-latest}"
     restart: always
     build:
-      context: ../pubky-core
+      context: ../pubky-homeserver
     volumes:
       - ./homeserver.config.toml:/config.toml
       - ./homeserver.entrypoint.sh:/entrypoint.sh

--- a/pubky-docker-cli.sh
+++ b/pubky-docker-cli.sh
@@ -10,7 +10,7 @@ BACKEND_ONLY=false
 BUILD_SERVICES=()
 PREPARED_COMMITS=()
 
-readonly GITHUB_CHECK_REPO="https://github.com/pubky/pubky-core.git"
+readonly GITHUB_CHECK_REPO="https://github.com/pubky/pubky-homeserver.git"
 readonly BUILD_STATE_FILE="$SCRIPT_DIR/.build-state"
 
 usage() {
@@ -306,7 +306,7 @@ EOF
 prepare_repos() {
   local repos=(
     "pubky-nexus|https://github.com/pubky/pubky-nexus.git|nexusd"
-    "pubky-core|https://github.com/pubky/pubky-core.git|homeserver"
+    "pubky-homeserver|https://github.com/pubky/pubky-homeserver.git|homeserver"
     "homegate|https://github.com/pubky/homegate.git|homegate"
   )
 


### PR DESCRIPTION
Updates the clone URL, local workspace path, Docker build context, and documentation for the renamed pubky-homeserver repository.