### PR TITLE
chore: pin Pubky 0.11.0

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -24,13 +24,13 @@ Only run this full orchestration if you are experimenting with the complete stac
 
 ## Using Public Docker Images (Recommended)
 
-All Pubky service images are published on the public [Synonymsoft registry](https://hub.docker.com/u/synonymsoft). By default, Compose uses the `latest` tag.
+All Pubky service images are published on the public [Synonymsoft registry](https://hub.docker.com/u/synonymsoft). By default, Compose uses Pubky Homeserver `v0.11.0` and the `latest` tag for the other services.
 
 Image tags and registry can be overridden in `.env`:
 
 ```text
 REGISTRY          # default: synonymsoft
-HOMESERVER_TAG    # default: latest
+HOMESERVER_TAG    # default: v0.11.0
 PUBKY_NEXUS_TAG   # default: latest
 PUBKY_APP_TAG     # default: latest
 HOMEGATE_TAG      # default: latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
   homeserver:
     profiles: [backend]
     container_name: homeserver
-    image: "${REGISTRY:-synonymsoft}/homeserver-${HOMESERVER_ENV:-testnet}:${HOMESERVER_TAG:-latest}"
+    image: "${REGISTRY:-synonymsoft}/homeserver-${HOMESERVER_ENV:-testnet}:${HOMESERVER_TAG:-v0.11.0}"
     restart: always
     build:
       context: ../pubky-homeserver


### PR DESCRIPTION
Pins the default Pubky Homeserver image to `v0.11.0` and documents the new default.